### PR TITLE
Remove extraneous lines from end of secretsdump.py

### DIFF
--- a/Server/Modules/secretsdump.py
+++ b/Server/Modules/secretsdump.py
@@ -757,5 +757,3 @@ if __name__ == '__main__':
             import traceback
             traceback.print_exc()
         logging.error(e)
-int_exc()
-        logging.error(e)


### PR DESCRIPTION
Couple extra lines are present at the end of the file, triggering an indentation error. Lines don't appear to do anything, looks more like an accidental partial replication of the two lines previous.